### PR TITLE
Linux下添加桌面软件分类Network

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
         }
       ],
       "icon": "icon",
-      "category": "InstantMessaging"
+      "category": "InstantMessaging;Network"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
新增一个Network的category吧，没有的话，mate-desktop会归类到其他。每次都手动改一下…