### PR TITLE
增加截图和消息闪烁的配置项来允许关闭相关功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,44 +98,12 @@
       "owner": "nashaofu",
       "repo": "dingtalk"
     },
-    "mac": {
-      "target": "dmg",
-      "icon": "./resources/icons/icon.icns",
-      "category": "public.app-category.instant-messaging"
-    },
-    "win": {
-      "icon": "./resources/icons/icon.ico",
-      "target": [
-        {
-          "target": "nsis",
-          "arch": [
-            "x64",
-            "ia32"
-          ]
-        }
-      ]
-    },
     "linux": {
       "target": [
         {
-          "target": "AppImage",
-          "arch": [
-            "x64",
-            "ia32"
-          ]
-        },
-        {
           "target": "deb",
           "arch": [
-            "x64",
-            "ia32"
-          ]
-        },
-        {
-          "target": "rpm",
-          "arch": [
-            "x64",
-            "ia32"
+            "x64"
           ]
         }
       ],

--- a/package.json
+++ b/package.json
@@ -98,12 +98,44 @@
       "owner": "nashaofu",
       "repo": "dingtalk"
     },
+    "mac": {
+      "target": "dmg",
+      "icon": "./resources/icons/icon.icns",
+      "category": "public.app-category.instant-messaging"
+    },
+    "win": {
+      "icon": "./resources/icons/icon.ico",
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
+      ]
+    },
     "linux": {
       "target": [
         {
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        },
+        {
           "target": "deb",
           "arch": [
-            "x64"
+            "x64",
+            "ia32"
+          ]
+        },
+        {
+          "target": "rpm",
+          "arch": [
+            "x64",
+            "ia32"
           ]
         }
       ],

--- a/src/main/dingtalk.js
+++ b/src/main/dingtalk.js
@@ -33,6 +33,8 @@ export default class DingTalk {
   // 默认配置
   setting = {
     autoupdate: true,
+    enableCapture: true,
+    enableFlicker: true,
     keymap: {
       'shortcut-capture': ['Control', 'Alt', 'A']
     }
@@ -92,7 +94,9 @@ export default class DingTalk {
    * 初始化截图
    */
   initShortcutCapture () {
-    this.$shortcutCapture = new ShortcutCapture()
+    if (this.setting.enableCapture){
+      this.$shortcutCapture = new ShortcutCapture()
+    }
   }
 
   /**
@@ -166,7 +170,7 @@ export default class DingTalk {
    * 截图
    */
   shortcutCapture () {
-    if (this.shortcutCapture) {
+    if (this.$shortcutCapture) {
       this.$shortcutCapture.shortcutCapture()
     }
   }

--- a/src/main/dingtalkTray.js
+++ b/src/main/dingtalkTray.js
@@ -28,30 +28,35 @@ export default class DingtalkTray {
    * 初始化菜单
    */
   initMenu () {
+    let menu = [
+      {
+        label: '显示窗口',
+        click: () => this._dingtalk.showMainWin()
+      },
+      {
+        label: '设置',
+        click: () => this._dingtalk.showSettingWin()
+      },
+      {
+        label: '关于',
+        click: () => this._dingtalk.showAboutWin()
+      },
+      {
+        label: '退出',
+        click: () => this._dingtalk.quit()
+      }
+    ]
+
+    if (this._dingtalk.setting.enableCapture) {
+      menu.splice(1, 0, {
+        label: '屏幕截图',
+        click: () => this._dingtalk.shortcutCapture()
+      })
+    }
+
     // 绑定菜单
     this.$tray.setContextMenu(
-      Menu.buildFromTemplate([
-        {
-          label: '显示窗口',
-          click: () => this._dingtalk.showMainWin()
-        },
-        {
-          label: '屏幕截图',
-          click: () => this._dingtalk.shortcutCapture()
-        },
-        {
-          label: '设置',
-          click: () => this._dingtalk.showSettingWin()
-        },
-        {
-          label: '关于',
-          click: () => this._dingtalk.showAboutWin()
-        },
-        {
-          label: '退出',
-          click: () => this._dingtalk.quit()
-        }
-      ])
+      Menu.buildFromTemplate(menu)
     )
   }
 
@@ -69,16 +74,24 @@ export default class DingtalkTray {
    */
   flicker (is) {
     if (is) {
-      // 防止连续调用多次，导致图标切换时间间隔不是1000ms
-      if (this._flickerTimer !== null) return
       let icon = this.messageTrayIcon
-      this._flickerTimer = setInterval(() => {
+
+      if (this._dingtalk.setting.enableFlicker) {
+        // 防止连续调用多次，导致图标切换时间间隔不是1000ms
+        if (this._flickerTimer !== null) return
+        this._flickerTimer = setInterval(() => {
+          this.$tray.setImage(icon)
+          icon = icon === this.messageTrayIcon ? this.noMessageTrayIcon : this.messageTrayIcon
+        }, 1000)
+      } else {
         this.$tray.setImage(icon)
-        icon = icon === this.messageTrayIcon ? this.noMessageTrayIcon : this.messageTrayIcon
-      }, 1000)
+      }
     } else {
-      clearInterval(this._flickerTimer)
-      this._flickerTimer = null
+      if (this._dingtalk.setting.enableFlicker && this._flickerTimer) {
+        clearInterval(this._flickerTimer)
+        this._flickerTimer = null
+      }
+
       this.$tray.setImage(this.noMessageTrayIcon)
     }
   }

--- a/src/main/setting.js
+++ b/src/main/setting.js
@@ -34,6 +34,13 @@ export const readSetting = dingtalk => () => {
         if (typeof setting.keymap['shortcut-capture'] === 'string') {
           setting.keymap['shortcut-capture'] = setting.keymap['shortcut-capture'].split('+')
         }
+
+        for (let name of ['enableCapture', 'enableFlicker']) {
+          if (!(name in setting)) {
+            setting[name] = true
+          }
+        }
+
         resolve({ ...dingtalk.setting, ...setting })
       } catch (e) {
         resolve(dingtalk.setting)

--- a/src/main/settingWin.js
+++ b/src/main/settingWin.js
@@ -13,7 +13,7 @@ export default dingtalk => () => {
   const $win = new BrowserWindow({
     title: '设置',
     width: 320,
-    height: 260,
+    height: 321,
     useContentSize: true,
     resizable: false,
     menu: false,

--- a/src/renderer/settingWin/App.vue
+++ b/src/renderer/settingWin/App.vue
@@ -1,14 +1,24 @@
 <template lang="pug">
 .app
   .app-item
-    dt-keybinding(
-      v-model="shortcutCapture",
+    dt-switch(
+      v-model="enableCapture",
       title="截图"
+    )
+    dt-keybinding(
+      :noTitle="true",
+      :disabled="!enableCapture",
+      v-model="shortcutCapture",
     )
   .app-item
     dt-switch(
       v-model="autoupdate",
       title="自动更新"
+    )
+  .app-item
+    dt-switch(
+      v-model="enableFlicker",
+      title="新消息闪烁"
     )
   .app-item
     .app-item-button
@@ -57,6 +67,28 @@ export default {
         this.setting = {
           ...this.setting,
           autoupdate: val
+        }
+      }
+    },
+    enableCapture: {
+      get () {
+        return !!this.setting.enableCapture
+      },
+      set (val) {
+        this.setting = {
+          ...this.setting,
+          enableCapture: val
+        }
+      }
+    },
+    enableFlicker: {
+      get () {
+        return !!this.setting.enableFlicker
+      },
+      set (val) {
+        this.setting = {
+          ...this.setting,
+          enableFlicker: val
         }
       }
     }

--- a/src/renderer/settingWin/components/keybinding/keybinding.vue
+++ b/src/renderer/settingWin/components/keybinding/keybinding.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .dt-keybinding
-  .dt-keybinding-title {{ title }}
+  .dt-keybinding-title(v-if="!noTitle") {{ title }}
   .dt-keybinding-value
     input(
       type="text",
@@ -28,6 +28,10 @@ export default {
       default: ''
     },
     disabled: {
+      type: Boolean,
+      default: false
+    },
+    noTitle: {
       type: Boolean,
       default: false
     }
@@ -120,6 +124,11 @@ export default {
         this.keys = this.value.map(key => upperFirst(key))
       } else {
         this.keys = []
+      }
+    },
+    toggle () {
+      if (!this.disabled) {
+        // this.$emit('input', !this.value)
       }
     }
   }

--- a/src/renderer/settingWin/components/keybinding/keybinding.vue
+++ b/src/renderer/settingWin/components/keybinding/keybinding.vue
@@ -125,11 +125,6 @@ export default {
       } else {
         this.keys = []
       }
-    },
-    toggle () {
-      if (!this.disabled) {
-        // this.$emit('input', !this.value)
-      }
     }
   }
 }


### PR DESCRIPTION
在Ubuntu 1804 / 1904下(其他系统未知)，存在两个问题
1. 图标闪烁在每次更新图标时，都会引起整个系统的短暂卡顿
2. 截图基本无法使用

所以加入了相关设置来允许关闭这两个功能